### PR TITLE
Task: Mozilla.Firefox.DeveloperEdition Fix prefix

### DIFF
--- a/Tasks/Mozilla.Firefox.DeveloperEdition/Script.ps1
+++ b/Tasks/Mozilla.Firefox.DeveloperEdition/Script.ps1
@@ -5,7 +5,7 @@ $ArchMap = [ordered]@{
   x64   = 'win64'
   arm64 = 'win64-aarch64'
 }
-$Prefix = 'https://download-installer.cdn.mozilla.net/pub/firefox/devedition/'
+$Prefix = 'https://download-installer.cdn.mozilla.net/pub/devedition/releases/'
 
 $Object1 = Invoke-RestMethod -Uri 'https://product-details.mozilla.org/1.0/firefox_versions.json'
 

--- a/Tasks/Mozilla.Firefox.DeveloperEdition/Script.ps1
+++ b/Tasks/Mozilla.Firefox.DeveloperEdition/Script.ps1
@@ -5,7 +5,7 @@ $ArchMap = [ordered]@{
   x64   = 'win64'
   arm64 = 'win64-aarch64'
 }
-$Prefix = 'https://download-installer.cdn.mozilla.net/pub/firefox/releases/'
+$Prefix = 'https://download-installer.cdn.mozilla.net/pub/firefox/devedition/'
 
 $Object1 = Invoke-RestMethod -Uri 'https://product-details.mozilla.org/1.0/firefox_versions.json'
 


### PR DESCRIPTION
Since f902e28b2be71f8caa776589d363941809de7961, it looks like installing non DeveloperEdition

I wish this fixes https://github.com/microsoft/winget-pkgs/issues/182357, however I did not complete any test with this script. Could you review?