### PR TITLE
Task GoLang.Go: Use version-specific ReleaseNotesUrl

### DIFF
--- a/Tasks/GoLang.Go/Script.ps1
+++ b/Tasks/GoLang.Go/Script.ps1
@@ -2,6 +2,8 @@ $Object1 = (Invoke-RestMethod -Uri 'https://go.dev/dl/?mode=json').Where({ $_.st
 
 # Version
 $this.CurrentState.Version = $Object1.version -replace '^go'
+# ReleaseNotesUrl
+$this.CurrentState.ReleaseNotesUrl = Join-Uri 'https://go.dev/doc/devel/release#' $Object1.version
 
 # Installer
 $this.CurrentState.Installer += [ordered]@{

--- a/Tasks/GoLang.Go/Script.ps1
+++ b/Tasks/GoLang.Go/Script.ps1
@@ -2,8 +2,6 @@ $Object1 = (Invoke-RestMethod -Uri 'https://go.dev/dl/?mode=json').Where({ $_.st
 
 # Version
 $this.CurrentState.Version = $Object1.version -replace '^go'
-# ReleaseNotesUrl
-$this.CurrentState.ReleaseNotesUrl = Join-Uri 'https://go.dev/doc/devel/release#' $Object1.version
 
 # Installer
 $this.CurrentState.Installer += [ordered]@{
@@ -25,6 +23,17 @@ $this.CurrentState.Installer += [ordered]@{
 
 switch -Regex ($this.Check()) {
   'New|Changed|Updated' {
+    try {
+      # ReleaseNotesUrl
+      $this.CurrentState.Locale += [ordered]@{
+        Key   = 'ReleaseNotesUrl'
+        Value = 'https://go.dev/doc/devel/release#' + $Object1.version
+      }
+    } catch {
+      $_ | Out-Host
+      $this.Log($_, 'Warning')
+    }
+
     try {
       $Object2 = Invoke-WebRequest -Uri 'https://go.dev/doc/devel/release' | ConvertFrom-Html
 


### PR DESCRIPTION
In task `GoLang.Go`, build the version-specific URL of release notes such as https://go.dev/doc/devel/release#go1.23.5 .

Motivation: the current manifest for Go 1.23.5 has a generic link to release notes which do not point to the specific release in the page. See https://github.com/microsoft/winget-pkgs/blob/master/manifests/g/GoLang/Go/1.23.5/GoLang.Go.locale.en-US.yaml#L29