### PR TITLE
Task: GoTo.GoTo - Add GoToMachine MSI installer

### DIFF
--- a/Tasks/GoTo.GoTo/Script.ps1
+++ b/Tasks/GoTo.GoTo/Script.ps1
@@ -35,6 +35,18 @@ $this.CurrentState.Installer += [ordered]@{
   Scope         = 'machine'
   InstallerUrl  = "https://goto-desktop.goto.com/GoToSetupUserLogin-$($this.CurrentState.Version)-x64.msi"
 }
+$this.CurrentState.Installer += [ordered]@{
+  Architecture  = 'x86'
+  InstallerType = 'msi'
+  Scope         = 'machine'
+  InstallerUrl  = "https://goto-desktop.goto.com/GoToSetupMachine-$($this.CurrentState.Version)-ia32.msi"
+}
+$this.CurrentState.Installer += [ordered]@{
+  Architecture  = 'x64'
+  InstallerType = 'msi'
+  Scope         = 'machine'
+  InstallerUrl  = "https://goto-desktop.goto.com/GoToSetupMachine-$($this.CurrentState.Version)-x64.msi"
+}
 
 switch -Regex ($this.Check()) {
   'New|Changed|Updated' {


### PR DESCRIPTION
This adds the .msi option alongside the .exe which I find works better with Intune.

The .msi option for the machine installer isn't visible in either of the latest.yml, but is still used to distribute.
<img width="733" height="259" alt="image" src="https://github.com/user-attachments/assets/5d564048-3660-4bf6-8ebd-f18a6ed637e9" />
