### PR TITLE
LibreWolf: Moved from GitLab to Codeberg and removed x86

### DIFF
--- a/Tasks/LibreWolf.LibreWolf/Script.ps1
+++ b/Tasks/LibreWolf.LibreWolf/Script.ps1
@@ -1,35 +1,26 @@
 $Object1 = Invoke-RestMethod -Uri 'https://codeberg.org/api/v1/repos/librewolf/bsys6/releases/latest'
 
 # Version
-$this.CurrentState.Version = $Object1.tag_name -creplace '^v'
-
-$Object2 = [ordered]@{}
-Invoke-RestMethod -Uri $Object1.assets.links.Where({ $_.name -eq 'sha256sums.txt' }, 'First')[0].url | Split-LineEndings |
-  Where-Object -FilterScript { $_.Contains('windows') -and $_.EndsWith('.exe') } |
-  ForEach-Object -Process {
-    $Entries = $_.Split('  ')
-    $Object2[$Entries[1]] = $Entries[0].ToUpper()
-  }
+$this.CurrentState.Version = $Object1.tag_name -replace '^v'
 
 # Installer
-$Asset = $Object1.assets.links.Where({ $_.name.EndsWith('.exe') -and $_.name.Contains('x86_64') }, 'First')[0]
 $this.CurrentState.Installer += [ordered]@{
-  Architecture    = 'x64'
-  InstallerType   = 'nullsoft'
-  InstallerUrl    = $Asset.url | ConvertTo-UnescapedUri
-  InstallerSha256 = $Object2[$Asset.name]
+  Architecture  = 'x64'
+  InstallerType = 'nullsoft'
+  InstallerUrl  = $Object1.assets.Where({ $_.name.EndsWith('.exe') -and $_.name.Contains('x86_64') }, 'First')[0].browser_download_url | ConvertTo-UnescapedUri
 }
 
 switch -Regex ($this.Check()) {
   'New|Changed|Updated' {
     try {
       # ReleaseTime
-      $this.CurrentState.ReleaseTime = $Object1.released_at.ToUniversalTime()
+      $this.CurrentState.ReleaseTime = $Object1.published_at.ToUniversalTime()
 
-      # ReleaseNotesUrl
+      # ReleaseNotesUrl (en-US)
       $this.CurrentState.Locale += [ordered]@{
-        Key   = 'ReleaseNotesUrl'
-        Value = $Object1._links.self
+        Locale = 'en-US'
+        Key    = 'ReleaseNotesUrl'
+        Value  = $Object1.html_url
       }
     } catch {
       $_ | Out-Host


### PR DESCRIPTION
Closes #72, it it works.

---

Edit: I first used this URL: <https://codeberg.org/api/v1/repos/librewolf/source/releases/latest>.

Then I noticed Scoop ( <https://github.com/ScoopInstaller/Extras/blob/master/bucket/librewolf.json> ) uses <https://codeberg.org/api/v1/repos/librewolf/bsys6/releases/latest>, which returned more data, which it seems the logic of Dumplings use.

---

Edit 2: Noticerd in the PR to Scoop that changed to Codeberg ( <https://github.com/ScoopInstaller/Extras/pull/17000> ) also removed x86, as LibreWolf does not build it anymore:

* <https://codeberg.org/librewolf/bsys6/commit/c0a4d71b51a0862ae23995d0d367ad27cb18ae3c>