### PR TITLE
Granola.Granola: Resolve installer to a stable URL

### DIFF
--- a/Tasks/Granola.Granola/Script.ps1
+++ b/Tasks/Granola.Granola/Script.ps1
@@ -1,14 +1,13 @@
 $Prefix = 'https://api.granola.ai/v1/check-for-update/'
 
 $Object1 = Invoke-RestMethod -Uri "${Prefix}latest.yml" | ConvertFrom-Yaml
-$InstallerUrl = Get-RedirectedUrl -Uri (Join-Uri $Prefix $Object1.files[0].url)
 
 # Version
 $this.CurrentState.Version = $Object1.version
 
 # Installer
 $this.CurrentState.Installer += [ordered]@{
-  InstallerUrl = $InstallerUrl
+  InstallerUrl = Get-RedirectedUrl -Uri (Join-Uri $Prefix $Object1.files[0].url)
 }
 
 switch -Regex ($this.Check()) {

--- a/Tasks/Granola.Granola/Script.ps1
+++ b/Tasks/Granola.Granola/Script.ps1
@@ -1,13 +1,14 @@
 $Prefix = 'https://api.granola.ai/v1/check-for-update/'
 
 $Object1 = Invoke-RestMethod -Uri "${Prefix}latest.yml" | ConvertFrom-Yaml
+$InstallerUrl = Get-RedirectedUrl -Uri (Join-Uri $Prefix $Object1.files[0].url)
 
 # Version
 $this.CurrentState.Version = $Object1.version
 
 # Installer
 $this.CurrentState.Installer += [ordered]@{
-  InstallerUrl = Join-Uri $Prefix $Object1.files[0].url
+  InstallerUrl = $InstallerUrl
 }
 
 switch -Regex ($this.Check()) {


### PR DESCRIPTION
Currently this script results in an installer URL like `https://api.granola.ai/v1/check-for-update/Granola-7.220.0-win-x64.exe`
(e.g. https://github.com/microsoft/winget-pkgs/pull/374603/changes)

This URL isn't actually stable and breaks when a new version of Granola is released.

Instead you should fetch `https://api.granola.ai/v1/check-for-update/Granola-7.220.0-win-x64.exe` and save the redirect (a long-term CDN URL) e.g. `https://dr2v7l5emb758.cloudfront.net/7.220.0/Granola-7.220.0-win-x64.exe`

I tweaked the Granola script to resolve that redirect

this will help fix https://github.com/fleetdm/fleet/issues/45359