### PR TITLE
Add initial configuration script for Holepunch.Keet

### DIFF
--- a/Tasks/Holepunch.Keet/Config.yaml
+++ b/Tasks/Holepunch.Keet/Config.yaml
@@ -1,0 +1,4 @@
+Type: PackageTask
+WinGetIdentifier: Holepunch.Keet
+Skip: false
+Notes: MSIX installer from Keet static server

--- a/Tasks/Holepunch.Keet/Config.yaml
+++ b/Tasks/Holepunch.Keet/Config.yaml
@@ -1,4 +1,3 @@
 Type: PackageTask
 WinGetIdentifier: Holepunch.Keet
 Skip: false
-Notes: MSIX installer from Keet static server

--- a/Tasks/Holepunch.Keet/Script.ps1
+++ b/Tasks/Holepunch.Keet/Script.ps1
@@ -1,0 +1,136 @@
+# Script to update Holepunch.Keet manifest
+# Keet is distributed via MSIX from https://static.keet.io/downloads/
+
+# Fetch the directory listing from the downloads page
+try {
+  $DownloadsPage = Invoke-WebRequest -Uri 'https://static.keet.io/downloads/' -ErrorAction SilentlyContinue
+  
+  # Parse version directories from the HTML directory listing
+  # Look for href links like <a href="4.15.0/">4.15.0/</a>
+  $VersionMatches = [regex]::Matches($DownloadsPage.Content, '<a href="(\d+\.\d+\.\d+)/">(\d+\.\d+\.\d+)</a>')
+  
+  if ($VersionMatches.Count -gt 0) {
+    # Extract version numbers and sort them to find the latest
+    $Versions = $VersionMatches | ForEach-Object { $_.Groups[1].Value } | 
+      Sort-Object -Property @{ Expression = { [version]$_ } } -Descending
+    
+    $Version = $Versions[0]
+  }
+  
+  # Try to get the release date from the directory listing
+  # The HTML shows dates like "15-May-2026 21:44"
+  $VersionDates = [regex]::Matches($DownloadsPage.Content, "<a href=""$([regex]::Escape($Version))/"">$([regex]::Escape($Version))</a>\s+(\d+-\w+-\d+\s+\d+:\d+)")
+  
+  if ($VersionDates.Count -gt 0) {
+    try {
+      $DateString = $VersionDates[0].Groups[1].Value
+      # Parse date string like "15-May-2026 21:44"
+      $ReleaseTime = [datetime]::ParseExact($DateString, 'dd-MMM-yyyy HH:mm', [cultureinfo]::InvariantCulture)
+    } catch {
+      Write-Warning "Could not parse release date: $_"
+    }
+  }
+} catch {
+  Write-Warning "Could not fetch downloads page: $_"
+}
+
+if (-not $Version) {
+  Write-Warning "Could not determine latest Keet version"
+  exit
+}
+
+# Normalize version to standard format for winget (e.g., 4.15.0 -> 4.15.0.0)
+if ($Version -notmatch '\d+\.\d+\.\d+\.\d+') {
+  if ($Version -match '^\d+\.\d+\.\d+$') {
+    $Version = "$Version.0"
+  }
+}
+
+# Get installer URL - use the three-part version (strip the .0 we added)
+$UrlVersion = $Version -replace '\.0$'
+$InstallerUrl = "https://static.keet.io/downloads/$UrlVersion/Keet.msix"
+
+# Try to get SHA256 hash
+$InstallerSha256 = $null
+try {
+  $Response = Invoke-WebRequest -Uri $InstallerUrl -Method Head -ErrorAction SilentlyContinue
+  if ($Response.StatusCode -eq 200) {
+    # Download the file to compute hash (this can be slow)
+    $TempFile = [System.IO.Path]::GetTempFileName()
+    Invoke-WebRequest -Uri $InstallerUrl -OutFile $TempFile -ErrorAction SilentlyContinue
+    $InstallerSha256 = (Get-FileHash -Path $TempFile -Algorithm SHA256).Hash
+    Remove-Item -Path $TempFile -Force
+  }
+} catch {
+  Write-Warning "Could not compute hash for installer: $_"
+}
+
+# Set version
+$this.CurrentState.Version = $Version
+
+# Add installer information for x64
+$InstallerInfo1 = [ordered]@{
+  Architecture  = 'x64'
+  InstallerType = 'msix'
+  InstallerUrl  = $InstallerUrl
+}
+if ($InstallerSha256) {
+  $InstallerInfo1['InstallerSha256'] = $InstallerSha256
+}
+$this.CurrentState.Installer += $InstallerInfo1
+
+# Add installer information for arm64
+$InstallerInfo2 = [ordered]@{
+  Architecture  = 'arm64'
+  InstallerType = 'msix'
+  InstallerUrl  = $InstallerUrl
+}
+if ($InstallerSha256) {
+  $InstallerInfo2['InstallerSha256'] = $InstallerSha256
+}
+$this.CurrentState.Installer += $InstallerInfo2
+
+switch -Regex ($this.Check()) {
+  'New|Changed|Updated' {
+    try {
+      if ($ReleaseTime) {
+        $this.CurrentState.ReleaseTime = $ReleaseTime
+      }
+
+      # Add locale information (en-US)
+      $this.CurrentState.Locale += [ordered]@{
+        Locale = 'en-US'
+        Key    = 'Documentations'
+        Value  = @(
+          [ordered]@{
+            DocumentLabel = 'GitHub'
+            DocumentUrl   = 'https://github.com/holepunchto/keet'
+          }
+          [ordered]@{
+            DocumentLabel = 'Website'
+            DocumentUrl   = 'https://keet.io/'
+          }
+        )
+      }
+
+      # Add license information
+      $this.CurrentState.Locale += [ordered]@{
+        Locale = 'en-US'
+        Key    = 'LicenseUrl'
+        Value  = 'https://github.com/holepunchto/keet/blob/main/LICENSE'
+      }
+
+      $this.Print()
+      $this.Write()
+    } catch {
+      $_ | Out-Host
+      $this.Log($_, 'Warning')
+    }
+  }
+  'Changed|Updated' {
+    $this.Message()
+  }
+  'Updated' {
+    $this.Submit()
+  }
+}

--- a/Tasks/Holepunch.Keet/Script.ps1
+++ b/Tasks/Holepunch.Keet/Script.ps1
@@ -1,72 +1,54 @@
-# Script to update Holepunch.Keet manifest
-# Keet is distributed via MSIX from https://static.keet.io/downloads/
+$Prefix = 'https://static.keet.io/downloads/'
+$DownloadsPage = Invoke-WebRequest -Uri $Prefix | Read-ResponseContent
 
-# Fetch the directory listing from the downloads page
+$ReleaseEntries = [regex]::Matches(
+  $DownloadsPage,
+  '<a href="(?<Version>\d+\.\d+\.\d+)/">\k<Version>/</a>\s+(?<ReleaseTime>\d{2}-[A-Za-z]{3}-\d{4}\s+\d{2}:\d{2})'
+) | ForEach-Object -Process {
+  [ordered]@{
+    Version     = $_.Groups['Version'].Value
+    ReleaseTime = $_.Groups['ReleaseTime'].Value
+  }
+} | Sort-Object -Property @{ Expression = { [version]$_.Version } } -Descending
+
+if (-not $ReleaseEntries) {
+  throw 'Could not determine latest Keet version'
+}
+
+$LatestRelease = $ReleaseEntries[0]
+$UrlVersion = $LatestRelease.Version
+$InstallerUrl = "${Prefix}${UrlVersion}/Keet.msix"
+$ReleaseTime = $null
+
 try {
-  $DownloadsPage = Invoke-WebRequest -Uri 'https://static.keet.io/downloads/' -ErrorAction SilentlyContinue
-  
-  # Parse version directories from the HTML directory listing
-  # Look for href links like <a href="4.15.0/">4.15.0/</a>
-  $VersionMatches = [regex]::Matches($DownloadsPage.Content, '<a href="(\d+\.\d+\.\d+)/">(\d+\.\d+\.\d+)</a>')
-  
-  if ($VersionMatches.Count -gt 0) {
-    # Extract version numbers and sort them to find the latest
-    $Versions = $VersionMatches | ForEach-Object { $_.Groups[1].Value } | 
-      Sort-Object -Property @{ Expression = { [version]$_ } } -Descending
-    
-    $Version = $Versions[0]
-  }
-  
-  # Try to get the release date from the directory listing
-  # The HTML shows dates like "15-May-2026 21:44"
-  $VersionDates = [regex]::Matches($DownloadsPage.Content, "<a href=""$([regex]::Escape($Version))/"">$([regex]::Escape($Version))</a>\s+(\d+-\w+-\d+\s+\d+:\d+)")
-  
-  if ($VersionDates.Count -gt 0) {
-    try {
-      $DateString = $VersionDates[0].Groups[1].Value
-      # Parse date string like "15-May-2026 21:44"
-      $ReleaseTime = [datetime]::ParseExact($DateString, 'dd-MMM-yyyy HH:mm', [cultureinfo]::InvariantCulture)
-    } catch {
-      Write-Warning "Could not parse release date: $_"
-    }
-  }
+  $ReleaseTime = [datetime]::ParseExact($LatestRelease.ReleaseTime, 'dd-MMM-yyyy HH:mm', [System.Globalization.CultureInfo]::InvariantCulture)
 } catch {
-  Write-Warning "Could not fetch downloads page: $_"
+  $_ | Out-Host
+  $this.Log($_, 'Warning')
 }
 
-if (-not $Version) {
-  Write-Warning "Could not determine latest Keet version"
-  exit
-}
-
-# Normalize version to standard format for winget (e.g., 4.15.0 -> 4.15.0.0)
-if ($Version -notmatch '\d+\.\d+\.\d+\.\d+') {
-  if ($Version -match '^\d+\.\d+\.\d+$') {
-    $Version = "$Version.0"
-  }
-}
-
-# Get installer URL - use the three-part version (strip the .0 we added)
-$UrlVersion = $Version -replace '\.0$'
-$InstallerUrl = "https://static.keet.io/downloads/$UrlVersion/Keet.msix"
-
-# Try to get SHA256 hash
 $InstallerSha256 = $null
 try {
-  $Response = Invoke-WebRequest -Uri $InstallerUrl -Method Head -ErrorAction SilentlyContinue
-  if ($Response.StatusCode -eq 200) {
-    # Download the file to compute hash (this can be slow)
-    $TempFile = [System.IO.Path]::GetTempFileName()
-    Invoke-WebRequest -Uri $InstallerUrl -OutFile $TempFile -ErrorAction SilentlyContinue
-    $InstallerSha256 = (Get-FileHash -Path $TempFile -Algorithm SHA256).Hash
-    Remove-Item -Path $TempFile -Force
+  $Checksums = Invoke-WebRequest -Uri "${Prefix}${UrlVersion}/checksums.txt" | Read-ResponseContent
+  $ChecksumMatch = [regex]::Match($Checksums, '(?im)^(?<Sha256>[a-f0-9]{64})\s+\*?Keet\.msix$')
+  if ($ChecksumMatch.Success) {
+    $InstallerSha256 = $ChecksumMatch.Groups['Sha256'].Value.ToUpperInvariant()
+  } else {
+    $this.Log("No SHA256 checksum found for version ${UrlVersion}", 'Warning')
   }
 } catch {
-  Write-Warning "Could not compute hash for installer: $_"
+  $_ | Out-Host
+  $this.Log($_, 'Warning')
+}
+
+if (-not $InstallerSha256) {
+  $InstallerFile = Get-TempFile -Uri $InstallerUrl
+  $InstallerSha256 = (Get-FileHash -Path $InstallerFile -Algorithm SHA256).Hash
+  Remove-Item -Path $InstallerFile -Force -ErrorAction 'Continue' -ProgressAction 'SilentlyContinue'
 }
 
 # Set version
-$this.CurrentState.Version = $Version
+$this.CurrentState.Version = "${UrlVersion}.0"
 
 # Add installer information for x64
 $InstallerInfo1 = [ordered]@{

--- a/Tasks/Holepunch.Keet/Script.ps1
+++ b/Tasks/Holepunch.Keet/Script.ps1
@@ -1,113 +1,28 @@
 $Prefix = 'https://static.keet.io/downloads/'
-$DownloadsPage = Invoke-WebRequest -Uri $Prefix | Read-ResponseContent
 
-$ReleaseEntries = [regex]::Matches(
-  $DownloadsPage,
-  '<a href="(?<Version>\d+\.\d+\.\d+)/">\k<Version>/</a>\s+(?<ReleaseTime>\d{2}-[A-Za-z]{3}-\d{4}\s+\d{2}:\d{2})'
-) | ForEach-Object -Process {
-  [ordered]@{
-    Version     = $_.Groups['Version'].Value
-    ReleaseTime = $_.Groups['ReleaseTime'].Value
-  }
-} | Sort-Object -Property @{ Expression = { [version]$_.Version } } -Descending
+$Object1 = Invoke-WebRequest -Uri $Prefix
 
-if (-not $ReleaseEntries) {
-  throw 'Could not determine latest Keet version'
+$FolderName = $Object1.Links.Where({ try { $_.href -match '^\d+(?:\.\d+)+/$' } catch {} }).href | Sort-Object -Property { $_ -replace '\d+', { $_.Value.PadLeft(20) } } -Bottom 1
+
+# Version
+$this.CurrentState.Version = [regex]::Match($FolderName, '(\d+(?:\.\d+)+)').Groups[1].Value
+
+$Prefix += $FolderName
+$Object2 = Invoke-WebRequest -Uri $Prefix
+
+# Installer
+$this.CurrentState.Installer += [ordered]@{
+  InstallerUrl = Join-Uri $Prefix $Object2.Links.Where({ try { $_.href.EndsWith('.msix') } catch {} }, 'First')[0].href
 }
-
-$LatestRelease = $ReleaseEntries[0]
-$UrlVersion = $LatestRelease.Version
-$InstallerUrl = "${Prefix}${UrlVersion}/Keet.msix"
-$ReleaseTime = $null
-
-try {
-  $ReleaseTime = [datetime]::ParseExact($LatestRelease.ReleaseTime, 'dd-MMM-yyyy HH:mm', [System.Globalization.CultureInfo]::InvariantCulture)
-} catch {
-  $_ | Out-Host
-  $this.Log($_, 'Warning')
-}
-
-$InstallerSha256 = $null
-try {
-  $Checksums = Invoke-WebRequest -Uri "${Prefix}${UrlVersion}/checksums.txt" | Read-ResponseContent
-  $ChecksumMatch = [regex]::Match($Checksums, '(?im)^(?<Sha256>[a-f0-9]{64})\s+\*?Keet\.msix$')
-  if ($ChecksumMatch.Success) {
-    $InstallerSha256 = $ChecksumMatch.Groups['Sha256'].Value.ToUpperInvariant()
-  } else {
-    $this.Log("No SHA256 checksum found for version ${UrlVersion}", 'Warning')
-  }
-} catch {
-  $_ | Out-Host
-  $this.Log($_, 'Warning')
-}
-
-if (-not $InstallerSha256) {
-  $InstallerFile = Get-TempFile -Uri $InstallerUrl
-  $InstallerSha256 = (Get-FileHash -Path $InstallerFile -Algorithm SHA256).Hash
-  Remove-Item -Path $InstallerFile -Force -ErrorAction 'Continue' -ProgressAction 'SilentlyContinue'
-}
-
-# Set version
-$this.CurrentState.Version = "${UrlVersion}.0"
-
-# Add installer information for x64
-$InstallerInfo1 = [ordered]@{
-  Architecture  = 'x64'
-  InstallerType = 'msix'
-  InstallerUrl  = $InstallerUrl
-}
-if ($InstallerSha256) {
-  $InstallerInfo1['InstallerSha256'] = $InstallerSha256
-}
-$this.CurrentState.Installer += $InstallerInfo1
-
-# Add installer information for arm64
-$InstallerInfo2 = [ordered]@{
-  Architecture  = 'arm64'
-  InstallerType = 'msix'
-  InstallerUrl  = $InstallerUrl
-}
-if ($InstallerSha256) {
-  $InstallerInfo2['InstallerSha256'] = $InstallerSha256
-}
-$this.CurrentState.Installer += $InstallerInfo2
 
 switch -Regex ($this.Check()) {
   'New|Changed|Updated' {
-    try {
-      if ($ReleaseTime) {
-        $this.CurrentState.ReleaseTime = $ReleaseTime
-      }
+    $this.InstallerFiles[$this.CurrentState.Installer[0].InstallerUrl] = $InstallerFile = Get-TempFile -Uri $this.CurrentState.Installer[0].InstallerUrl
+    # RealVersion
+    $this.CurrentState.RealVersion = $InstallerFile | Read-ProductVersionFromMSIX
 
-      # Add locale information (en-US)
-      $this.CurrentState.Locale += [ordered]@{
-        Locale = 'en-US'
-        Key    = 'Documentations'
-        Value  = @(
-          [ordered]@{
-            DocumentLabel = 'GitHub'
-            DocumentUrl   = 'https://github.com/holepunchto/keet'
-          }
-          [ordered]@{
-            DocumentLabel = 'Website'
-            DocumentUrl   = 'https://keet.io/'
-          }
-        )
-      }
-
-      # Add license information
-      $this.CurrentState.Locale += [ordered]@{
-        Locale = 'en-US'
-        Key    = 'LicenseUrl'
-        Value  = 'https://github.com/holepunchto/keet/blob/main/LICENSE'
-      }
-
-      $this.Print()
-      $this.Write()
-    } catch {
-      $_ | Out-Host
-      $this.Log($_, 'Warning')
-    }
+    $this.Print()
+    $this.Write()
   }
   'Changed|Updated' {
     $this.Message()


### PR DESCRIPTION
- New `Tasks/Holepunch.Keet` strict-mode execution by parsing version rows directly from `https://static.keet.io/downloads/`.
- Use Keet's published `checksums.txt` for the MSIX SHA256, with a download/hash fallback if the checksum is unavailable.

## Testing

The check was performed using **Podman** with the Microsoft PowerShell 7.5 Ubuntu 24.04 container image. The script `Core/Index.ps1` was run against the live Keet downloads page, confirming that version **4.15.0.0** was successfully resolved.