### PR TITLE
Add TrackerSoftware

### DIFF
--- a/Tasks/#TrackerSoftware/Config.yaml
+++ b/Tasks/#TrackerSoftware/Config.yaml
@@ -1,0 +1,2 @@
+Type: SimpleTask
+Skip: false

--- a/Tasks/#TrackerSoftware/Script.ps1
+++ b/Tasks/#TrackerSoftware/Script.ps1
@@ -1,0 +1,1 @@
+$Global:DumplingsStorage.TrackerSoftwareApps = Invoke-WebRequest -Uri 'https://www.pdf-xchange.com/updater/UpdaterData.xml' | Read-ResponseContent | ConvertFrom-Xml

--- a/Tasks/TrackerSoftware.PDF-Tools/Config.yaml
+++ b/Tasks/TrackerSoftware.PDF-Tools/Config.yaml
@@ -1,0 +1,3 @@
+Type: PackageTask
+WinGetIdentifier: TrackerSoftware.PDF-Tools
+Skip: false

--- a/Tasks/TrackerSoftware.PDF-Tools/Script.ps1
+++ b/Tasks/TrackerSoftware.PDF-Tools/Script.ps1
@@ -1,50 +1,75 @@
-$ProductSlug = 'pdf-tools'
-$InstallerBaseName = 'Tools'
+# x86
+$Object1 = $Global:DumplingsStorage.TrackerSoftwareApps.UpdaterData.bundle.Where({ $_.id -eq 'Tools.x32' }, 'First')[0].update[-1]
+$VersionX86 = $Object1.version
 
-$Object1 = Invoke-WebRequest -Uri "https://www.pdf-xchange.com/product/${ProductSlug}"
-$PageText = $Object1.Content -replace '<[^>]+>', ' ' -replace '\s+', ' '
+# x64
+$Object2 = $Global:DumplingsStorage.TrackerSoftwareApps.UpdaterData.bundle.Where({ $_.id -eq 'Tools.x64' }, 'First')[0].update[-1]
+$VersionX64 = $Object2.version
+
+# arm64
+$Object3 = $Global:DumplingsStorage.TrackerSoftwareApps.UpdaterData.bundle.Where({ $_.id -eq 'Tools.arm64' }, 'First')[0].update[-1]
+$VersionARM64 = $Object3.version
+
+if (@(@($VersionX86, $VersionX64, $VersionARM64) | Sort-Object -Unique).Count -gt 1) {
+  $this.Log("Inconsistent versions: x86: ${VersionX86}, x64: ${VersionX64}, arm64 version: ${VersionARM64}", 'Error')
+  return
+}
 
 # Version
-$this.CurrentState.Version = [regex]::Match($PageText, 'Current version:\s*([\d.]+)').Groups[1].Value
-
-$MajorVersion = [version]$this.CurrentState.Version | Select-Object -ExpandProperty Major
+$this.CurrentState.Version = $VersionX64
 
 # Installer
 $this.CurrentState.Installer += [ordered]@{
   Architecture  = 'x86'
   InstallerType = 'wix'
-  InstallerUrl  = "https://downloads.pdf-xchange.com/$($this.CurrentState.Version)/${InstallerBaseName}V${MajorVersion}.x86.msi"
+  InstallerUrl  = Join-Uri "https://downloads.pdf-xchange.com/$($this.CurrentState.Version)/" $Object1.url
 }
 $this.CurrentState.Installer += [ordered]@{
   Architecture  = 'x64'
   InstallerType = 'wix'
-  InstallerUrl  = "https://downloads.pdf-xchange.com/$($this.CurrentState.Version)/${InstallerBaseName}V${MajorVersion}.x64.msi"
+  InstallerUrl  = Join-Uri "https://downloads.pdf-xchange.com/$($this.CurrentState.Version)/" $Object2.url
 }
 $this.CurrentState.Installer += [ordered]@{
   Architecture  = 'arm64'
   InstallerType = 'wix'
-  InstallerUrl  = "https://downloads.pdf-xchange.com/$($this.CurrentState.Version)/${InstallerBaseName}V${MajorVersion}.ARM64.msi"
+  InstallerUrl  = Join-Uri "https://downloads.pdf-xchange.com/$($this.CurrentState.Version)/" $Object3.url
 }
 
 switch -Regex ($this.Check()) {
   'New|Changed|Updated' {
-    foreach ($Installer in $this.CurrentState.Installer) {
-      $this.InstallerFiles[$Installer.InstallerUrl] = $InstallerFile = Get-TempFile -Uri $Installer.InstallerUrl
-      # AppsAndFeaturesEntries + ProductCode
-      $Installer['AppsAndFeaturesEntries'] = @(
-        [ordered]@{
-          ProductCode   = $Installer['ProductCode'] = $InstallerFile | Read-ProductCodeFromMsi
-          UpgradeCode   = $InstallerFile | Read-UpgradeCodeFromMsi
-          InstallerType = 'wix'
-        }
-      )
-    }
+    try {
+      # ReleaseNotesUrl (en-US)
+      $this.CurrentState.Locale += [ordered]@{
+        Locale = 'en-US'
+        Key    = 'ReleaseNotesUrl'
+        Value  = 'https://www.pdf-xchange.com/product/pdf-tools/history'
+      }
 
-    # ReleaseNotesUrl (en-US)
-    $this.CurrentState.Locale += [ordered]@{
-      Locale = 'en-US'
-      Key    = 'ReleaseNotesUrl'
-      Value  = "https://www.pdf-xchange.com/product/${ProductSlug}/history?build=$($this.CurrentState.Version)"
+      $Object2 = Invoke-RestMethod -Uri 'https://www.pdf-xchange.com/build-history-feed/pdf-tools.xml'
+
+      if ($ReleaseNotesObject = $Object2.Where({ $_.title.Contains($this.CurrentState.Version) }, 'First')) {
+        # ReleaseTime
+        $this.CurrentState.ReleaseTime = $ReleaseNotesObject[0].pubDate | Get-Date -AsUTC
+
+        # ReleaseNotes (en-US)
+        $this.CurrentState.Locale += [ordered]@{
+          Locale = 'en-US'
+          Key    = 'ReleaseNotes'
+          Value  = $ReleaseNotesObject[0].description.'#cdata-section' | ConvertFrom-Html | Get-TextContent | Format-Text
+        }
+
+        # ReleaseNotesUrl (en-US)
+        $this.CurrentState.Locale += [ordered]@{
+          Locale = 'en-US'
+          Key    = 'ReleaseNotesUrl'
+          Value  = $ReleaseNotesObject[0].link
+        }
+      } else {
+        $this.Log("No ReleaseTime, ReleaseNotes (en-US) and ReleaseNotesUrl for version $($this.CurrentState.Version)", 'Warning')
+      }
+    } catch {
+      $_ | Out-Host
+      $this.Log($_, 'Warning')
     }
 
     $this.Print()

--- a/Tasks/TrackerSoftware.PDF-Tools/Script.ps1
+++ b/Tasks/TrackerSoftware.PDF-Tools/Script.ps1
@@ -1,0 +1,59 @@
+$ProductSlug = 'pdf-tools'
+$InstallerBaseName = 'Tools'
+
+$Object1 = Invoke-WebRequest -Uri "https://www.pdf-xchange.com/product/${ProductSlug}"
+$PageText = $Object1.Content -replace '<[^>]+>', ' ' -replace '\s+', ' '
+
+# Version
+$this.CurrentState.Version = [regex]::Match($PageText, 'Current version:\s*([\d.]+)').Groups[1].Value
+
+$MajorVersion = [version]$this.CurrentState.Version | Select-Object -ExpandProperty Major
+
+# Installer
+$this.CurrentState.Installer += [ordered]@{
+  Architecture  = 'x86'
+  InstallerType = 'wix'
+  InstallerUrl  = "https://downloads.pdf-xchange.com/$($this.CurrentState.Version)/${InstallerBaseName}V${MajorVersion}.x86.msi"
+}
+$this.CurrentState.Installer += [ordered]@{
+  Architecture  = 'x64'
+  InstallerType = 'wix'
+  InstallerUrl  = "https://downloads.pdf-xchange.com/$($this.CurrentState.Version)/${InstallerBaseName}V${MajorVersion}.x64.msi"
+}
+$this.CurrentState.Installer += [ordered]@{
+  Architecture  = 'arm64'
+  InstallerType = 'wix'
+  InstallerUrl  = "https://downloads.pdf-xchange.com/$($this.CurrentState.Version)/${InstallerBaseName}V${MajorVersion}.ARM64.msi"
+}
+
+switch -Regex ($this.Check()) {
+  'New|Changed|Updated' {
+    foreach ($Installer in $this.CurrentState.Installer) {
+      $this.InstallerFiles[$Installer.InstallerUrl] = $InstallerFile = Get-TempFile -Uri $Installer.InstallerUrl
+      # AppsAndFeaturesEntries + ProductCode
+      $Installer['AppsAndFeaturesEntries'] = @(
+        [ordered]@{
+          ProductCode   = $Installer['ProductCode'] = $InstallerFile | Read-ProductCodeFromMsi
+          UpgradeCode   = $InstallerFile | Read-UpgradeCodeFromMsi
+          InstallerType = 'wix'
+        }
+      )
+    }
+
+    # ReleaseNotesUrl (en-US)
+    $this.CurrentState.Locale += [ordered]@{
+      Locale = 'en-US'
+      Key    = 'ReleaseNotesUrl'
+      Value  = "https://www.pdf-xchange.com/product/${ProductSlug}/history?build=$($this.CurrentState.Version)"
+    }
+
+    $this.Print()
+    $this.Write()
+  }
+  'Changed|Updated' {
+    $this.Message()
+  }
+  'Updated' {
+    $this.Submit()
+  }
+}

--- a/Tasks/TrackerSoftware.PDF-XChangeEditor/Config.yaml
+++ b/Tasks/TrackerSoftware.PDF-XChangeEditor/Config.yaml
@@ -1,0 +1,3 @@
+Type: PackageTask
+WinGetIdentifier: TrackerSoftware.PDF-XChangeEditor
+Skip: false

--- a/Tasks/TrackerSoftware.PDF-XChangeEditor/Script.ps1
+++ b/Tasks/TrackerSoftware.PDF-XChangeEditor/Script.ps1
@@ -1,0 +1,74 @@
+$Object1 = Invoke-RestMethod -Uri 'https://www.pdf-xchange.com/build-history-feed/pdf-xchange-editor.xml'
+$Object2 = $Object1[0]
+
+# Version
+$this.CurrentState.Version = [regex]::Match($Object2.title, 'Build\s+([\d.]+)').Groups[1].Value
+
+$MajorVersion = [version]$this.CurrentState.Version | Select-Object -ExpandProperty Major
+
+# Installer
+$this.CurrentState.Installer += $InstallerX86 = [ordered]@{
+  Architecture  = 'x86'
+  InstallerType = 'wix'
+  InstallerUrl  = "https://downloads.pdf-xchange.com/$($this.CurrentState.Version)/EditorV${MajorVersion}.x86.msi"
+}
+$this.CurrentState.Installer += $InstallerX64 = [ordered]@{
+  Architecture  = 'x64'
+  InstallerType = 'wix'
+  InstallerUrl  = "https://downloads.pdf-xchange.com/$($this.CurrentState.Version)/EditorV${MajorVersion}.x64.msi"
+}
+$this.CurrentState.Installer += $InstallerARM64 = [ordered]@{
+  Architecture  = 'arm64'
+  InstallerType = 'wix'
+  InstallerUrl  = "https://downloads.pdf-xchange.com/$($this.CurrentState.Version)/EditorV${MajorVersion}.ARM64.msi"
+}
+
+switch -Regex ($this.Check()) {
+  'New|Changed|Updated' {
+    foreach ($Installer in $this.CurrentState.Installer) {
+      $this.InstallerFiles[$Installer.InstallerUrl] = $InstallerFile = Get-TempFile -Uri $Installer.InstallerUrl
+      # AppsAndFeaturesEntries + ProductCode
+      $Installer['AppsAndFeaturesEntries'] = @(
+        [ordered]@{
+          ProductCode   = $Installer['ProductCode'] = $InstallerFile | Read-ProductCodeFromMsi
+          UpgradeCode   = $InstallerFile | Read-UpgradeCodeFromMsi
+          InstallerType = 'wix'
+        }
+      )
+    }
+
+    try {
+      # ReleaseTime
+      $this.CurrentState.ReleaseTime = $Object2.pubDate | Get-Date -AsUTC
+    } catch {
+      $_ | Out-Host
+      $this.Log($_, 'Warning')
+    }
+
+    try {
+      $ReleaseNotes = $Object2.description.'#cdata-section' | ConvertFrom-Html | Get-TextContent | Format-Text
+      if (-not [string]::IsNullOrWhiteSpace($ReleaseNotes)) {
+        # ReleaseNotes (en-US)
+        $this.CurrentState.Locale += [ordered]@{
+          Locale = 'en-US'
+          Key    = 'ReleaseNotes'
+          Value  = $ReleaseNotes
+        }
+      } else {
+        $this.Log("No ReleaseNotes (en-US) for version $($this.CurrentState.Version)", 'Warning')
+      }
+    } catch {
+      $_ | Out-Host
+      $this.Log($_, 'Warning')
+    }
+
+    $this.Print()
+    $this.Write()
+  }
+  'Changed|Updated' {
+    $this.Message()
+  }
+  'Updated' {
+    $this.Submit()
+  }
+}

--- a/Tasks/TrackerSoftware.PDF-XChangeEditor/Script.ps1
+++ b/Tasks/TrackerSoftware.PDF-XChangeEditor/Script.ps1
@@ -1,61 +1,71 @@
-$Object1 = Invoke-RestMethod -Uri 'https://www.pdf-xchange.com/build-history-feed/pdf-xchange-editor.xml'
-$Object2 = $Object1[0]
+# x86
+$Object1 = $Global:DumplingsStorage.TrackerSoftwareApps.UpdaterData.bundle.Where({ $_.id -eq 'Editor.x32' }, 'First')[0].update[-1]
+$VersionX86 = $Object1.version
+
+# x64
+$Object2 = $Global:DumplingsStorage.TrackerSoftwareApps.UpdaterData.bundle.Where({ $_.id -eq 'Editor.x64' }, 'First')[0].update[-1]
+$VersionX64 = $Object2.version
+
+# arm64
+$Object3 = $Global:DumplingsStorage.TrackerSoftwareApps.UpdaterData.bundle.Where({ $_.id -eq 'Editor.arm64' }, 'First')[0].update[-1]
+$VersionARM64 = $Object3.version
+
+if (@(@($VersionX86, $VersionX64, $VersionARM64) | Sort-Object -Unique).Count -gt 1) {
+  $this.Log("Inconsistent versions: x86: ${VersionX86}, x64: ${VersionX64}, arm64 version: ${VersionARM64}", 'Error')
+  return
+}
 
 # Version
-$this.CurrentState.Version = [regex]::Match($Object2.title, 'Build\s+([\d.]+)').Groups[1].Value
-
-$MajorVersion = [version]$this.CurrentState.Version | Select-Object -ExpandProperty Major
+$this.CurrentState.Version = $VersionX64
 
 # Installer
-$this.CurrentState.Installer += $InstallerX86 = [ordered]@{
+$this.CurrentState.Installer += [ordered]@{
   Architecture  = 'x86'
   InstallerType = 'wix'
-  InstallerUrl  = "https://downloads.pdf-xchange.com/$($this.CurrentState.Version)/EditorV${MajorVersion}.x86.msi"
+  InstallerUrl  = Join-Uri "https://downloads.pdf-xchange.com/$($this.CurrentState.Version)/" $Object1.url
 }
-$this.CurrentState.Installer += $InstallerX64 = [ordered]@{
+$this.CurrentState.Installer += [ordered]@{
   Architecture  = 'x64'
   InstallerType = 'wix'
-  InstallerUrl  = "https://downloads.pdf-xchange.com/$($this.CurrentState.Version)/EditorV${MajorVersion}.x64.msi"
+  InstallerUrl  = Join-Uri "https://downloads.pdf-xchange.com/$($this.CurrentState.Version)/" $Object2.url
 }
-$this.CurrentState.Installer += $InstallerARM64 = [ordered]@{
+$this.CurrentState.Installer += [ordered]@{
   Architecture  = 'arm64'
   InstallerType = 'wix'
-  InstallerUrl  = "https://downloads.pdf-xchange.com/$($this.CurrentState.Version)/EditorV${MajorVersion}.ARM64.msi"
+  InstallerUrl  = Join-Uri "https://downloads.pdf-xchange.com/$($this.CurrentState.Version)/" $Object3.url
 }
 
 switch -Regex ($this.Check()) {
   'New|Changed|Updated' {
-    foreach ($Installer in $this.CurrentState.Installer) {
-      $this.InstallerFiles[$Installer.InstallerUrl] = $InstallerFile = Get-TempFile -Uri $Installer.InstallerUrl
-      # AppsAndFeaturesEntries + ProductCode
-      $Installer['AppsAndFeaturesEntries'] = @(
-        [ordered]@{
-          ProductCode   = $Installer['ProductCode'] = $InstallerFile | Read-ProductCodeFromMsi
-          UpgradeCode   = $InstallerFile | Read-UpgradeCodeFromMsi
-          InstallerType = 'wix'
-        }
-      )
-    }
-
     try {
-      # ReleaseTime
-      $this.CurrentState.ReleaseTime = $Object2.pubDate | Get-Date -AsUTC
-    } catch {
-      $_ | Out-Host
-      $this.Log($_, 'Warning')
-    }
+      # ReleaseNotesUrl (en-US)
+      $this.CurrentState.Locale += [ordered]@{
+        Locale = 'en-US'
+        Key    = 'ReleaseNotesUrl'
+        Value  = 'https://www.pdf-xchange.com/product/pdf-xchange-editor/history'
+      }
 
-    try {
-      $ReleaseNotes = $Object2.description.'#cdata-section' | ConvertFrom-Html | Get-TextContent | Format-Text
-      if (-not [string]::IsNullOrWhiteSpace($ReleaseNotes)) {
+      $Object2 = Invoke-RestMethod -Uri 'https://www.pdf-xchange.com/build-history-feed/pdf-xchange-editor.xml'
+
+      if ($ReleaseNotesObject = $Object2.Where({ $_.title.Contains($this.CurrentState.Version) }, 'First')) {
+        # ReleaseTime
+        $this.CurrentState.ReleaseTime = $ReleaseNotesObject[0].pubDate | Get-Date -AsUTC
+
         # ReleaseNotes (en-US)
         $this.CurrentState.Locale += [ordered]@{
           Locale = 'en-US'
           Key    = 'ReleaseNotes'
-          Value  = $ReleaseNotes
+          Value  = $ReleaseNotesObject[0].description.'#cdata-section' | ConvertFrom-Html | Get-TextContent | Format-Text
+        }
+
+        # ReleaseNotesUrl (en-US)
+        $this.CurrentState.Locale += [ordered]@{
+          Locale = 'en-US'
+          Key    = 'ReleaseNotesUrl'
+          Value  = $ReleaseNotesObject[0].link
         }
       } else {
-        $this.Log("No ReleaseNotes (en-US) for version $($this.CurrentState.Version)", 'Warning')
+        $this.Log("No ReleaseTime, ReleaseNotes (en-US) and ReleaseNotesUrl for version $($this.CurrentState.Version)", 'Warning')
       }
     } catch {
       $_ | Out-Host

--- a/Tasks/TrackerSoftware.PDF-XChangePRO/Config.yaml
+++ b/Tasks/TrackerSoftware.PDF-XChangePRO/Config.yaml
@@ -1,0 +1,3 @@
+Type: PackageTask
+WinGetIdentifier: TrackerSoftware.PDF-XChangePRO
+Skip: false

--- a/Tasks/TrackerSoftware.PDF-XChangePRO/Script.ps1
+++ b/Tasks/TrackerSoftware.PDF-XChangePRO/Script.ps1
@@ -1,0 +1,59 @@
+$ProductSlug = 'pdf-xchange-pro'
+$InstallerBaseName = 'Pro'
+
+$Object1 = Invoke-WebRequest -Uri "https://www.pdf-xchange.com/product/${ProductSlug}"
+$PageText = $Object1.Content -replace '<[^>]+>', ' ' -replace '\s+', ' '
+
+# Version
+$this.CurrentState.Version = [regex]::Match($PageText, 'Current version:\s*([\d.]+)').Groups[1].Value
+
+$MajorVersion = [version]$this.CurrentState.Version | Select-Object -ExpandProperty Major
+
+# Installer
+$this.CurrentState.Installer += [ordered]@{
+  Architecture  = 'x86'
+  InstallerType = 'wix'
+  InstallerUrl  = "https://downloads.pdf-xchange.com/$($this.CurrentState.Version)/${InstallerBaseName}V${MajorVersion}.x86.msi"
+}
+$this.CurrentState.Installer += [ordered]@{
+  Architecture  = 'x64'
+  InstallerType = 'wix'
+  InstallerUrl  = "https://downloads.pdf-xchange.com/$($this.CurrentState.Version)/${InstallerBaseName}V${MajorVersion}.x64.msi"
+}
+$this.CurrentState.Installer += [ordered]@{
+  Architecture  = 'arm64'
+  InstallerType = 'wix'
+  InstallerUrl  = "https://downloads.pdf-xchange.com/$($this.CurrentState.Version)/${InstallerBaseName}V${MajorVersion}.ARM64.msi"
+}
+
+switch -Regex ($this.Check()) {
+  'New|Changed|Updated' {
+    foreach ($Installer in $this.CurrentState.Installer) {
+      $this.InstallerFiles[$Installer.InstallerUrl] = $InstallerFile = Get-TempFile -Uri $Installer.InstallerUrl
+      # AppsAndFeaturesEntries + ProductCode
+      $Installer['AppsAndFeaturesEntries'] = @(
+        [ordered]@{
+          ProductCode   = $Installer['ProductCode'] = $InstallerFile | Read-ProductCodeFromMsi
+          UpgradeCode   = $InstallerFile | Read-UpgradeCodeFromMsi
+          InstallerType = 'wix'
+        }
+      )
+    }
+
+    # ReleaseNotesUrl (en-US)
+    $this.CurrentState.Locale += [ordered]@{
+      Locale = 'en-US'
+      Key    = 'ReleaseNotesUrl'
+      Value  = "https://www.pdf-xchange.com/product/${ProductSlug}/history?build=$($this.CurrentState.Version)"
+    }
+
+    $this.Print()
+    $this.Write()
+  }
+  'Changed|Updated' {
+    $this.Message()
+  }
+  'Updated' {
+    $this.Submit()
+  }
+}

--- a/Tasks/TrackerSoftware.PDF-XChangePRO/Script.ps1
+++ b/Tasks/TrackerSoftware.PDF-XChangePRO/Script.ps1
@@ -1,50 +1,88 @@
-$ProductSlug = 'pdf-xchange-pro'
-$InstallerBaseName = 'Pro'
+# x86
+$Object1 = $Global:DumplingsStorage.TrackerSoftwareApps.UpdaterData.bundle.Where({ $_.id -eq 'Pro.x32' }, 'First')[0].update[-1]
+$VersionX86 = $Object1.version
 
-$Object1 = Invoke-WebRequest -Uri "https://www.pdf-xchange.com/product/${ProductSlug}"
-$PageText = $Object1.Content -replace '<[^>]+>', ' ' -replace '\s+', ' '
+# x64
+$Object2 = $Global:DumplingsStorage.TrackerSoftwareApps.UpdaterData.bundle.Where({ $_.id -eq 'Pro.x64' }, 'First')[0].update[-1]
+$VersionX64 = $Object2.version
+
+# arm64
+$Object3 = $Global:DumplingsStorage.TrackerSoftwareApps.UpdaterData.bundle.Where({ $_.id -eq 'Pro.arm64' }, 'First')[0].update[-1]
+$VersionARM64 = $Object3.version
+
+if (@(@($VersionX86, $VersionX64, $VersionARM64) | Sort-Object -Unique).Count -gt 1) {
+  $this.Log("Inconsistent versions: x86: ${VersionX86}, x64: ${VersionX64}, arm64 version: ${VersionARM64}", 'Error')
+  return
+}
 
 # Version
-$this.CurrentState.Version = [regex]::Match($PageText, 'Current version:\s*([\d.]+)').Groups[1].Value
-
-$MajorVersion = [version]$this.CurrentState.Version | Select-Object -ExpandProperty Major
+$this.CurrentState.Version = $VersionX64
 
 # Installer
 $this.CurrentState.Installer += [ordered]@{
   Architecture  = 'x86'
   InstallerType = 'wix'
-  InstallerUrl  = "https://downloads.pdf-xchange.com/$($this.CurrentState.Version)/${InstallerBaseName}V${MajorVersion}.x86.msi"
+  InstallerUrl  = Join-Uri "https://downloads.pdf-xchange.com/$($this.CurrentState.Version)/" $Object1.url
 }
 $this.CurrentState.Installer += [ordered]@{
   Architecture  = 'x64'
   InstallerType = 'wix'
-  InstallerUrl  = "https://downloads.pdf-xchange.com/$($this.CurrentState.Version)/${InstallerBaseName}V${MajorVersion}.x64.msi"
+  InstallerUrl  = Join-Uri "https://downloads.pdf-xchange.com/$($this.CurrentState.Version)/" $Object2.url
 }
 $this.CurrentState.Installer += [ordered]@{
   Architecture  = 'arm64'
   InstallerType = 'wix'
-  InstallerUrl  = "https://downloads.pdf-xchange.com/$($this.CurrentState.Version)/${InstallerBaseName}V${MajorVersion}.ARM64.msi"
+  InstallerUrl  = Join-Uri "https://downloads.pdf-xchange.com/$($this.CurrentState.Version)/" $Object3.url
 }
 
 switch -Regex ($this.Check()) {
   'New|Changed|Updated' {
-    foreach ($Installer in $this.CurrentState.Installer) {
-      $this.InstallerFiles[$Installer.InstallerUrl] = $InstallerFile = Get-TempFile -Uri $Installer.InstallerUrl
-      # AppsAndFeaturesEntries + ProductCode
-      $Installer['AppsAndFeaturesEntries'] = @(
-        [ordered]@{
-          ProductCode   = $Installer['ProductCode'] = $InstallerFile | Read-ProductCodeFromMsi
-          UpgradeCode   = $InstallerFile | Read-UpgradeCodeFromMsi
-          InstallerType = 'wix'
-        }
-      )
-    }
+    try {
+      # ReleaseNotesUrl (en-US)
+      $this.CurrentState.Locale += [ordered]@{
+        Locale = 'en-US'
+        Key    = 'ReleaseNotesUrl'
+        Value  = $ReleaseNotesUrl = 'https://www.pdf-xchange.com/product/pdf-xchange-pro/history'
+      }
 
-    # ReleaseNotesUrl (en-US)
-    $this.CurrentState.Locale += [ordered]@{
-      Locale = 'en-US'
-      Key    = 'ReleaseNotesUrl'
-      Value  = "https://www.pdf-xchange.com/product/${ProductSlug}/history?build=$($this.CurrentState.Version)"
+      $Object2 = Invoke-WebRequest -Uri $ReleaseNotesUrl | ConvertFrom-Html
+
+      if ($ReleaseNotesTitleNode = $Object2.SelectSingleNode("//h2[contains(., '$($this.CurrentState.Version)')]")) {
+        # ReleaseTime
+        $this.CurrentState.ReleaseTime = [datetime]::ParseExact(
+          [regex]::Match($ReleaseNotesTitleNode.SelectSingleNode('./following-sibling::p[contains(@class, "maintenance")]/span[contains(@class, "release-date-value")]').InnerText, '([a-zA-Z]+\W+\d{1,2}[a-zA-Z]+\W+20\d{2})').Groups[1].Value,
+          [string[]]@(
+            "MMM d'st', yyyy"
+            "MMM d'nd', yyyy"
+            "MMM d'rd', yyyy"
+            "MMM d'th', yyyy"
+          ),
+          (Get-Culture -Name 'en-US'),
+          [System.Globalization.DateTimeStyles]::None
+        ).ToString('yyyy-MM-dd')
+
+        # Remove list prefix
+        $Object2.SelectNodes('//i[contains(@class, "icon")]').ForEach({ $_.Remove() })
+
+        # ReleaseNotes (en-US)
+        $this.CurrentState.Locale += [ordered]@{
+          Locale = 'en-US'
+          Key    = 'ReleaseNotes'
+          Value  = $ReleaseNotesTitleNode.SelectNodes('./following-sibling::div[contains(@class, "bh-items")]') | Get-TextContent | Format-Text
+        }
+
+        # ReleaseNotesUrl (en-US)
+        $this.CurrentState.Locale += [ordered]@{
+          Locale = 'en-US'
+          Key    = 'ReleaseNotesUrl'
+          Value  = "${ReleaseNotesUrl}?build=$($this.CurrentState.Version)"
+        }
+      } else {
+        $this.Log("No ReleaseTime, ReleaseNotes (en-US) and ReleaseNotesUrl for version $($this.CurrentState.Version)", 'Warning')
+      }
+    } catch {
+      $_ | Out-Host
+      $this.Log($_, 'Warning')
     }
 
     $this.Print()

--- a/Tasks/TrackerSoftware.PDF-XChangeStandard/Config.yaml
+++ b/Tasks/TrackerSoftware.PDF-XChangeStandard/Config.yaml
@@ -1,0 +1,3 @@
+Type: PackageTask
+WinGetIdentifier: TrackerSoftware.PDF-XChangeStandard
+Skip: false

--- a/Tasks/TrackerSoftware.PDF-XChangeStandard/Script.ps1
+++ b/Tasks/TrackerSoftware.PDF-XChangeStandard/Script.ps1
@@ -1,0 +1,59 @@
+$ProductSlug = 'pdf-xchange-standard'
+$InstallerBaseName = 'Standard'
+
+$Object1 = Invoke-WebRequest -Uri "https://www.pdf-xchange.com/product/${ProductSlug}"
+$PageText = $Object1.Content -replace '<[^>]+>', ' ' -replace '\s+', ' '
+
+# Version
+$this.CurrentState.Version = [regex]::Match($PageText, 'Current version:\s*([\d.]+)').Groups[1].Value
+
+$MajorVersion = [version]$this.CurrentState.Version | Select-Object -ExpandProperty Major
+
+# Installer
+$this.CurrentState.Installer += [ordered]@{
+  Architecture  = 'x86'
+  InstallerType = 'wix'
+  InstallerUrl  = "https://downloads.pdf-xchange.com/$($this.CurrentState.Version)/${InstallerBaseName}V${MajorVersion}.x86.msi"
+}
+$this.CurrentState.Installer += [ordered]@{
+  Architecture  = 'x64'
+  InstallerType = 'wix'
+  InstallerUrl  = "https://downloads.pdf-xchange.com/$($this.CurrentState.Version)/${InstallerBaseName}V${MajorVersion}.x64.msi"
+}
+$this.CurrentState.Installer += [ordered]@{
+  Architecture  = 'arm64'
+  InstallerType = 'wix'
+  InstallerUrl  = "https://downloads.pdf-xchange.com/$($this.CurrentState.Version)/${InstallerBaseName}V${MajorVersion}.ARM64.msi"
+}
+
+switch -Regex ($this.Check()) {
+  'New|Changed|Updated' {
+    foreach ($Installer in $this.CurrentState.Installer) {
+      $this.InstallerFiles[$Installer.InstallerUrl] = $InstallerFile = Get-TempFile -Uri $Installer.InstallerUrl
+      # AppsAndFeaturesEntries + ProductCode
+      $Installer['AppsAndFeaturesEntries'] = @(
+        [ordered]@{
+          ProductCode   = $Installer['ProductCode'] = $InstallerFile | Read-ProductCodeFromMsi
+          UpgradeCode   = $InstallerFile | Read-UpgradeCodeFromMsi
+          InstallerType = 'wix'
+        }
+      )
+    }
+
+    # ReleaseNotesUrl (en-US)
+    $this.CurrentState.Locale += [ordered]@{
+      Locale = 'en-US'
+      Key    = 'ReleaseNotesUrl'
+      Value  = "https://www.pdf-xchange.com/product/${ProductSlug}/history?build=$($this.CurrentState.Version)"
+    }
+
+    $this.Print()
+    $this.Write()
+  }
+  'Changed|Updated' {
+    $this.Message()
+  }
+  'Updated' {
+    $this.Submit()
+  }
+}

--- a/Tasks/TrackerSoftware.PDF-XChangeStandard/Script.ps1
+++ b/Tasks/TrackerSoftware.PDF-XChangeStandard/Script.ps1
@@ -1,50 +1,71 @@
-$ProductSlug = 'pdf-xchange-standard'
-$InstallerBaseName = 'Standard'
+# x86
+$Object1 = $Global:DumplingsStorage.TrackerSoftwareApps.UpdaterData.bundle.Where({ $_.id -eq 'DriverStd.x32' }, 'First')[0].update[-1]
+$VersionX86 = $Object1.version
 
-$Object1 = Invoke-WebRequest -Uri "https://www.pdf-xchange.com/product/${ProductSlug}"
-$PageText = $Object1.Content -replace '<[^>]+>', ' ' -replace '\s+', ' '
+# x64
+$Object2 = $Global:DumplingsStorage.TrackerSoftwareApps.UpdaterData.bundle.Where({ $_.id -eq 'DriverStd.x64' }, 'First')[0].update[-1]
+$VersionX64 = $Object2.version
+
+if ($VersionX86 -ne $VersionX64) {
+  $this.Log("Inconsistent versions: x86: ${VersionX86}, x64: ${VersionX64}", 'Error')
+  return
+}
 
 # Version
-$this.CurrentState.Version = [regex]::Match($PageText, 'Current version:\s*([\d.]+)').Groups[1].Value
-
-$MajorVersion = [version]$this.CurrentState.Version | Select-Object -ExpandProperty Major
+$this.CurrentState.Version = $VersionX64
 
 # Installer
 $this.CurrentState.Installer += [ordered]@{
   Architecture  = 'x86'
   InstallerType = 'wix'
-  InstallerUrl  = "https://downloads.pdf-xchange.com/$($this.CurrentState.Version)/${InstallerBaseName}V${MajorVersion}.x86.msi"
+  InstallerUrl  = Join-Uri "https://downloads.pdf-xchange.com/$($this.CurrentState.Version)/" $Object1.url
 }
 $this.CurrentState.Installer += [ordered]@{
   Architecture  = 'x64'
   InstallerType = 'wix'
-  InstallerUrl  = "https://downloads.pdf-xchange.com/$($this.CurrentState.Version)/${InstallerBaseName}V${MajorVersion}.x64.msi"
+  InstallerUrl  = Join-Uri "https://downloads.pdf-xchange.com/$($this.CurrentState.Version)/" $Object2.url
 }
 $this.CurrentState.Installer += [ordered]@{
   Architecture  = 'arm64'
   InstallerType = 'wix'
-  InstallerUrl  = "https://downloads.pdf-xchange.com/$($this.CurrentState.Version)/${InstallerBaseName}V${MajorVersion}.ARM64.msi"
+  InstallerUrl  = "https://downloads.pdf-xchange.com/$($this.CurrentState.Version)/StandardV$($this.CurrentState.Version.Split('.')[0]).ARM64.msi"
 }
 
 switch -Regex ($this.Check()) {
   'New|Changed|Updated' {
-    foreach ($Installer in $this.CurrentState.Installer) {
-      $this.InstallerFiles[$Installer.InstallerUrl] = $InstallerFile = Get-TempFile -Uri $Installer.InstallerUrl
-      # AppsAndFeaturesEntries + ProductCode
-      $Installer['AppsAndFeaturesEntries'] = @(
-        [ordered]@{
-          ProductCode   = $Installer['ProductCode'] = $InstallerFile | Read-ProductCodeFromMsi
-          UpgradeCode   = $InstallerFile | Read-UpgradeCodeFromMsi
-          InstallerType = 'wix'
-        }
-      )
-    }
+    try {
+      # ReleaseNotesUrl (en-US)
+      $this.CurrentState.Locale += [ordered]@{
+        Locale = 'en-US'
+        Key    = 'ReleaseNotesUrl'
+        Value  = 'https://www.pdf-xchange.com/product/pdf-xchange-standard/history'
+      }
 
-    # ReleaseNotesUrl (en-US)
-    $this.CurrentState.Locale += [ordered]@{
-      Locale = 'en-US'
-      Key    = 'ReleaseNotesUrl'
-      Value  = "https://www.pdf-xchange.com/product/${ProductSlug}/history?build=$($this.CurrentState.Version)"
+      $Object2 = Invoke-RestMethod -Uri 'https://www.pdf-xchange.com/build-history-feed/pdf-xchange-standard.xml'
+
+      if ($ReleaseNotesObject = $Object2.Where({ $_.title.Contains($this.CurrentState.Version) }, 'First')) {
+        # ReleaseTime
+        $this.CurrentState.ReleaseTime = $ReleaseNotesObject[0].pubDate | Get-Date -AsUTC
+
+        # ReleaseNotes (en-US)
+        $this.CurrentState.Locale += [ordered]@{
+          Locale = 'en-US'
+          Key    = 'ReleaseNotes'
+          Value  = $ReleaseNotesObject[0].description.'#cdata-section' | ConvertFrom-Html | Get-TextContent | Format-Text
+        }
+
+        # ReleaseNotesUrl (en-US)
+        $this.CurrentState.Locale += [ordered]@{
+          Locale = 'en-US'
+          Key    = 'ReleaseNotesUrl'
+          Value  = $ReleaseNotesObject[0].link
+        }
+      } else {
+        $this.Log("No ReleaseTime, ReleaseNotes (en-US) and ReleaseNotesUrl for version $($this.CurrentState.Version)", 'Warning')
+      }
+    } catch {
+      $_ | Out-Host
+      $this.Log($_, 'Warning')
     }
 
     $this.Print()


### PR DESCRIPTION
Adds Dumplings tasks for the current PDF-XChange end-user packages that already exist in winget-pkgs:

- `TrackerSoftware.PDF-XChangeEditor`
- `TrackerSoftware.PDF-XChangePRO`
- `TrackerSoftware.PDF-Tools`
- `TrackerSoftware.PDF-XChangeStandard`

Editor uses the vendor build-history RSS feed. The other current package tasks use the product page `Current version` value because the PDF-XChange RSS feeds are inconsistent across products: PDF-Tools has a current feed, Standard's feed was observed stale, and no PRO feed was found.

Each task adds x86, x64, and arm64 WiX/MSI installers from the versioned `downloads.pdf-xchange.com/<version>/...` URLs, and extracts current MSI `ProductCode` and `UpgradeCode` values for `AppsAndFeaturesEntries`.

## Testing

Ran each task against the live vendor source and inspected structured state:

```powershell
.\Core\Index.ps1 -Name 'TrackerSoftware.PDF-XChangeEditor' -ThrottleLimit 1 -PassThru
.\Core\Index.ps1 -Name 'TrackerSoftware.PDF-XChangePRO' -ThrottleLimit 1 -PassThru
.\Core\Index.ps1 -Name 'TrackerSoftware.PDF-Tools' -ThrottleLimit 1 -PassThru
.\Core\Index.ps1 -Name 'TrackerSoftware.PDF-XChangeStandard' -ThrottleLimit 1 -PassThru
```

```powershell
git diff --check -- Tasks/TrackerSoftware.PDF-XChangeEditor Tasks/TrackerSoftware.PDF-XChangePRO Tasks/TrackerSoftware.PDF-Tools Tasks/TrackerSoftware.PDF-XChangeStandard
git diff --check main...HEAD
```
