### PR TITLE
Add Unity.UnityHub

### DIFF
--- a/Tasks/Unity.UnityHub/Config.yaml
+++ b/Tasks/Unity.UnityHub/Config.yaml
@@ -1,0 +1,3 @@
+Type: PackageTask
+WinGetIdentifier: Unity.UnityHub
+Skip: false

--- a/Tasks/Unity.UnityHub/Script.ps1
+++ b/Tasks/Unity.UnityHub/Script.ps1
@@ -1,30 +1,32 @@
-# Unity Hub — winget update task for SpecterShell/Dumplings.
-#
-# Discovers the current GA version from Unity Hub's electron-updater feed and
-# submits the immutable, version-pinned x64 installer URL. This mirrors the
-# Unity Editor tasks, which discover versions from a feed rather than from
-# installer-hash changes, so it works with pinned URLs (pinned URLs are what
-# keep older winget versions from being auto-deleted).
-$FeedBase = 'https://public-cdn.cloud.unity3d.com/hub/prod'
+$Prefix = 'https://public-cdn.cloud.unity3d.com/hub/prod/'
 
-# Version — latest.yml (the GA channel's electron-updater feed) carries the
-# current GA version.
-$Version = (Invoke-RestMethod -Uri "${FeedBase}/latest.yml" | ConvertFrom-Yaml).version
-$this.CurrentState.Version = $Version
+$Object1 = Invoke-RestMethod -Uri "${Prefix}latest.yml" | ConvertFrom-Yaml
 
-# Installer — build the immutable, version-pinned URL deterministically from the
-# version, matching the published layout (<base>/<version>/<file>) and the
-# installer file name. This intentionally does NOT reuse latest.yml's own file
-# paths, so the submitted URL stays pinned even if the feed ever points at the
-# rolling alias. x64 only: Unity Hub's Windows arm64 installer currently trips
-# winget's `Validation-Defender-Error` in the install test.
+# Version
+$this.CurrentState.Version = $Object1.version
+
+# Installer
 $this.CurrentState.Installer += [ordered]@{
-  Architecture = 'x64'
-  InstallerUrl = "${FeedBase}/${Version}/UnityHubSetup-${Version}-x64.exe"
+  Architecture  = 'x64'
+  InstallerType = 'nullsoft'
+  InstallerUrl  = Join-Uri $Prefix "$($this.CurrentState.Version)/UnityHubSetup-$($this.CurrentState.Version)-x64.exe"
+}
+$this.CurrentState.Installer += [ordered]@{
+  Architecture  = 'arm64'
+  InstallerType = 'nullsoft'
+  InstallerUrl  = Join-Uri $Prefix "$($this.CurrentState.Version)/UnityHubSetup-$($this.CurrentState.Version)-arm64.exe"
 }
 
 switch -Regex ($this.Check()) {
   'New|Changed|Updated' {
+    try {
+      # ReleaseTime
+      $this.CurrentState.ReleaseTime = $Object1.releaseDate | Get-Date -AsUTC
+    } catch {
+      $_ | Out-Host
+      $this.Log($_, 'Warning')
+    }
+
     $this.Print()
     $this.Write()
   }

--- a/Tasks/Unity.UnityHub/Script.ps1
+++ b/Tasks/Unity.UnityHub/Script.ps1
@@ -1,0 +1,37 @@
+# Unity Hub — winget update task for SpecterShell/Dumplings.
+#
+# Discovers the current GA version from Unity Hub's electron-updater feed and
+# submits the immutable, version-pinned x64 installer URL. This mirrors the
+# Unity Editor tasks, which discover versions from a feed rather than from
+# installer-hash changes, so it works with pinned URLs (pinned URLs are what
+# keep older winget versions from being auto-deleted).
+$FeedBase = 'https://public-cdn.cloud.unity3d.com/hub/prod'
+
+# Version — latest.yml (the GA channel's electron-updater feed) carries the
+# current GA version.
+$Version = (Invoke-RestMethod -Uri "${FeedBase}/latest.yml" | ConvertFrom-Yaml).version
+$this.CurrentState.Version = $Version
+
+# Installer — build the immutable, version-pinned URL deterministically from the
+# version, matching the published layout (<base>/<version>/<file>) and the
+# installer file name. This intentionally does NOT reuse latest.yml's own file
+# paths, so the submitted URL stays pinned even if the feed ever points at the
+# rolling alias. x64 only: Unity Hub's Windows arm64 installer currently trips
+# winget's `Validation-Defender-Error` in the install test.
+$this.CurrentState.Installer += [ordered]@{
+  Architecture = 'x64'
+  InstallerUrl = "${FeedBase}/${Version}/UnityHubSetup-${Version}-x64.exe"
+}
+
+switch -Regex ($this.Check()) {
+  'New|Changed|Updated' {
+    $this.Print()
+    $this.Write()
+  }
+  'Changed|Updated' {
+    $this.Message()
+  }
+  'Updated' {
+    $this.Submit()
+  }
+}

--- a/Tasks/Unity.UnityHub/State.yaml
+++ b/Tasks/Unity.UnityHub/State.yaml
@@ -1,4 +1,0 @@
-Version: 3.19.4
-Installer:
-- Architecture: x64
-  InstallerUrl: https://public-cdn.cloud.unity3d.com/hub/prod/3.19.4/UnityHubSetup-3.19.4-x64.exe

--- a/Tasks/Unity.UnityHub/State.yaml
+++ b/Tasks/Unity.UnityHub/State.yaml
@@ -1,0 +1,4 @@
+Version: 3.19.4
+Installer:
+- Architecture: x64
+  InstallerUrl: https://public-cdn.cloud.unity3d.com/hub/prod/3.19.4/UnityHubSetup-3.19.4-x64.exe


### PR DESCRIPTION
Adds a Dumplings task for **Unity Hub** (winget `Unity.UnityHub`), which isn't currently tracked here.

**Why:** Unity Hub's winget manifests were relying on winget-pkgs' hash-mismatch auto-updater. Now that the manifests are pinned to immutable, version-scoped installer URLs (so `winget install --version` resolves correctly and stale versions stop getting auto-deleted), that auto-updater no longer fires. This task takes over version detection — the same approach as the existing `Unity.Unity.*` editor tasks, using Unity Hub's release feed instead of the Live Platform API.

**Version discovery:** Unity Hub publishes an electron-updater feed for its GA channel at `https://public-cdn.cloud.unity3d.com/hub/prod/latest.yml`. `Script.ps1` reads the `version` from it and builds the immutable installer URL deterministically (`.../hub/prod/<version>/UnityHubSetup-<version>-x64.exe`), matching the published layout and the NSIS installer file name.

**x64 only (intentional):** Unity Hub's Windows arm64 build currently trips winget's `Validation-Defender-Error` in the install test, so the script targets x64. A comment notes how to re-add arm64 if that clears.

`State.yaml` is seeded to the current live GA (3.19.4) so the first automation run is a no-op; the next GA release will be the first submission.
