### PR TITLE
DATEV.Belegtransfer: Submit on rollback-classified updates

### DIFF
--- a/Tasks/DATEV.Belegtransfer/Script.ps1
+++ b/Tasks/DATEV.Belegtransfer/Script.ps1
@@ -16,7 +16,11 @@ $this.CurrentState.Installer += [ordered]@{
 }
 
 switch -Regex ($this.Check()) {
-  'New|Changed|Updated' {
+  # DATEV's portal version string is not monotonic under WinGet chunk comparison
+  # (e.g. "5.5" sorts below "5.49" because chunk 5 < 49), so a genuine update can be
+  # classified as "Rollbacked". Treat rollbacks like updates, matching the other DATEV
+  # tasks. DATEV does not publish real downgrades on this channel.
+  'New|Changed|Updated|Rollbacked' {
     $this.InstallerFiles[$this.CurrentState.Installer[0].InstallerUrl] = $InstallerFile = Get-TempFile -Uri $this.CurrentState.Installer[0].InstallerUrl
     # RealVersion
     $this.CurrentState.RealVersion = $InstallerFile | Read-ProductVersionFromExe
@@ -24,10 +28,10 @@ switch -Regex ($this.Check()) {
     $this.Print()
     $this.Write()
   }
-  'Changed|Updated' {
+  'Changed|Updated|Rollbacked' {
     $this.Message()
   }
-  'Updated' {
+  'Updated|Rollbacked' {
     $this.Submit()
   }
 }


### PR DESCRIPTION
DATEV's download-portal version string is not monotonic under WinGet chunk comparison: a real update such as 5.49 -> 5.5 compares as a rollback because chunk "5" sorts below "49". Check() therefore returns "Rollbacked", which the switch ignored, so version 5.5 (published 2026-07-07) was never picked up or submitted.

Add Rollbacked to the download/message/submit branches, matching the existing DATEV.SmartITConnect and DATEV.SicherheitspaketCompact tasks. DATEV does not publish real downgrades on this channel.