### PR TITLE
EarendilWorks.pi: Add Windows ARM64 support

### DIFF
--- a/Tasks/EarendilWorks.pi/Config.yaml
+++ b/Tasks/EarendilWorks.pi/Config.yaml
@@ -1,3 +1,4 @@
 Type: PackageTask
 WinGetIdentifier: EarendilWorks.pi
+WinGetReplaceMode: true
 Skip: false

--- a/Tasks/EarendilWorks.pi/Config.yaml
+++ b/Tasks/EarendilWorks.pi/Config.yaml
@@ -1,4 +1,3 @@
 Type: PackageTask
 WinGetIdentifier: EarendilWorks.pi
-WinGetReplaceMode: true
 Skip: false

--- a/Tasks/EarendilWorks.pi/Script.ps1
+++ b/Tasks/EarendilWorks.pi/Script.ps1
@@ -4,11 +4,21 @@ $Object1 = Invoke-GitHubApi -Uri 'https://api.github.com/repos/earendil-works/pi
 $this.CurrentState.Version = $Object1.tag_name -replace '^v'
 
 # Installer
-$this.CurrentState.Installer += [ordered]@{
-  Architecture        = 'x64'
-  InstallerType       = 'zip'
-  NestedInstallerType = 'portable'
-  InstallerUrl        = $Object1.assets.Where({ $_.name.EndsWith('.zip') -and $_.name.Contains('x64') -and $_.name -match 'windows' }, 'First')[0].browser_download_url | ConvertTo-UnescapedUri
+foreach ($Architecture in @('x64', 'arm64')) {
+  $Assets = @($Object1.assets.Where({ $_.name -ceq "pi-windows-${Architecture}.zip" }))
+  if ($Assets.Count -ne 1) {
+    throw "Expected one Windows ${Architecture} ZIP asset, found $($Assets.Count)."
+  }
+
+  $this.CurrentState.Installer += [ordered]@{
+    Query        = [ordered]@{
+      Architecture        = 'x64'
+      InstallerType       = 'zip'
+      NestedInstallerType = 'portable'
+    }
+    Architecture = $Architecture
+    InstallerUrl = $Assets[0].browser_download_url | ConvertTo-UnescapedUri
+  }
 }
 
 switch -Regex ($this.Check()) {

--- a/Tasks/EarendilWorks.pi/Script.ps1
+++ b/Tasks/EarendilWorks.pi/Script.ps1
@@ -4,21 +4,17 @@ $Object1 = Invoke-GitHubApi -Uri 'https://api.github.com/repos/earendil-works/pi
 $this.CurrentState.Version = $Object1.tag_name -replace '^v'
 
 # Installer
-foreach ($Architecture in @('x64', 'arm64')) {
-  $Assets = @($Object1.assets.Where({ $_.name -ceq "pi-windows-${Architecture}.zip" }))
-  if ($Assets.Count -ne 1) {
-    throw "Expected one Windows ${Architecture} ZIP asset, found $($Assets.Count)."
-  }
-
-  $this.CurrentState.Installer += [ordered]@{
-    Query        = [ordered]@{
-      Architecture        = 'x64'
-      InstallerType       = 'zip'
-      NestedInstallerType = 'portable'
-    }
-    Architecture = $Architecture
-    InstallerUrl = $Assets[0].browser_download_url | ConvertTo-UnescapedUri
-  }
+$this.CurrentState.Installer += [ordered]@{
+  Architecture        = 'x64'
+  InstallerType       = 'zip'
+  NestedInstallerType = 'portable'
+  InstallerUrl        = $Object1.assets.Where({ $_.name.EndsWith('.zip') -and $_.name.Contains('x64') -and $_.name -match 'windows' }, 'First')[0].browser_download_url | ConvertTo-UnescapedUri
+}
+$this.CurrentState.Installer += [ordered]@{
+  Architecture        = 'arm64'
+  InstallerType       = 'zip'
+  NestedInstallerType = 'portable'
+  InstallerUrl        = $Object1.assets.Where({ $_.name.EndsWith('.zip') -and $_.name.Contains('arm64') -and $_.name -match 'windows' }, 'First')[0].browser_download_url | ConvertTo-UnescapedUri
 }
 
 switch -Regex ($this.Check()) {


### PR DESCRIPTION
## Summary

- discover both x64 and ARM64 Windows ZIP assets
- use replace mode to add the new ARM64 installer entry
- require exact release asset names to avoid ambiguous selection

## Validation

- PSScriptAnalyzer
- manifest update exercised against the published 0.84.2 manifest and both release ZIP assets