### PR TITLE
Unity.UnityHub: Use the four-part MSIX version and add ARP entries

### DIFF
--- a/Tasks/Unity.UnityHub/Script.ps1
+++ b/Tasks/Unity.UnityHub/Script.ps1
@@ -14,28 +14,14 @@ if ($Object1.version -match '^\d+\.\d+\.\d+$' -and [System.Version]$Object1.vers
 
 # Installer
 $this.CurrentState.Installer += [ordered]@{
-  Architecture           = 'x64'
-  InstallerType          = 'nullsoft'
-  InstallerUrl           = $InstallerUrl = Join-Uri $Prefix $Object1.files.Where({ $_.url.Contains('x64') }, 'First')[0].url
-  AppsAndFeaturesEntries = @(
-    [ordered]@{
-      DisplayName    = "Unity Hub $($Object1.version)"
-      DisplayVersion = $Object1.version
-      ProductCode    = 'Unity Technologies - Hub'
-    }
-  )
+  Architecture  = 'x64'
+  InstallerType = 'nullsoft'
+  InstallerUrl  = $InstallerUrl = Join-Uri $Prefix $Object1.files.Where({ $_.url.Contains('x64') }, 'First')[0].url
 }
 $this.CurrentState.Installer += [ordered]@{
-  Architecture           = 'arm64'
-  InstallerType          = 'nullsoft'
-  InstallerUrl           = $InstallerUrl.Replace('x64', 'arm64')
-  AppsAndFeaturesEntries = @(
-    [ordered]@{
-      DisplayName    = "Unity Hub $($Object1.version)"
-      DisplayVersion = $Object1.version
-      ProductCode    = 'Unity Technologies - Hub'
-    }
-  )
+  Architecture  = 'arm64'
+  InstallerType = 'nullsoft'
+  InstallerUrl  = $InstallerUrl.Replace('x64', 'arm64')
 }
 $this.CurrentState.Installer += [ordered]@{
   Architecture  = 'x64'

--- a/Tasks/Unity.UnityHub/Script.ps1
+++ b/Tasks/Unity.UnityHub/Script.ps1
@@ -5,16 +5,37 @@ $Object1 = Invoke-RestMethod -Uri "${Prefix}latest.yml" | ConvertFrom-Yaml
 # Version
 $this.CurrentState.Version = $Object1.version
 
+# RealVersion
+# Since 3.21.0, Unity Hub encodes the release channel in the fourth field of the MSIX Identity/@Version, mapping GA to 65535 (earlier releases shipped X.Y.Z.0).
+# WinGet requires PackageVersion to agree with the MSIX identity, so the manifest version is the four-part encoding while the ARP entries below keep the three-part product version.
+if ($Object1.version -match '^\d+\.\d+\.\d+$' -and [System.Version]$Object1.version -ge [System.Version]'3.21.0') {
+  $this.CurrentState.RealVersion = "$($Object1.version).65535"
+}
+
 # Installer
 $this.CurrentState.Installer += [ordered]@{
-  Architecture  = 'x64'
-  InstallerType = 'nullsoft'
-  InstallerUrl  = $InstallerUrl = Join-Uri $Prefix $Object1.files.Where({ $_.url.Contains('x64') }, 'First')[0].url
+  Architecture           = 'x64'
+  InstallerType          = 'nullsoft'
+  InstallerUrl           = $InstallerUrl = Join-Uri $Prefix $Object1.files.Where({ $_.url.Contains('x64') }, 'First')[0].url
+  AppsAndFeaturesEntries = @(
+    [ordered]@{
+      DisplayName    = "Unity Hub $($Object1.version)"
+      DisplayVersion = $Object1.version
+      ProductCode    = 'Unity Technologies - Hub'
+    }
+  )
 }
 $this.CurrentState.Installer += [ordered]@{
-  Architecture  = 'arm64'
-  InstallerType = 'nullsoft'
-  InstallerUrl  = $InstallerUrl.Replace('x64', 'arm64')
+  Architecture           = 'arm64'
+  InstallerType          = 'nullsoft'
+  InstallerUrl           = $InstallerUrl.Replace('x64', 'arm64')
+  AppsAndFeaturesEntries = @(
+    [ordered]@{
+      DisplayName    = "Unity Hub $($Object1.version)"
+      DisplayVersion = $Object1.version
+      ProductCode    = 'Unity Technologies - Hub'
+    }
+  )
 }
 $this.CurrentState.Installer += [ordered]@{
   Architecture  = 'x64'


### PR DESCRIPTION
Follow-up to #124, which I contributed. I maintain Unity Hub's releases, and the manifests this task generates have stopped validating upstream.

## The problem

Since **3.21.0**, Unity Hub's MSIX packages encode the release channel in the fourth field of `Identity/@Version`, with GA mapped to `65535` (3.20.1 and earlier shipped `X.Y.Z.0`). WinGet requires `PackageVersion` to be consistent with the MSIX identity, so the three-part version this task emits is rejected:

```
Manifest Error: Inconsistent value in the manifest. [PackageVersion] Value: 3.21.0.65535
```

That is why microsoft/winget-pkgs#419999 (this task's 3.21.0 submission) cannot pass validation. I have submitted the corrected manifests by hand as microsoft/winget-pkgs#421150, using `PackageVersion: 3.21.0.65535`. Without this change the task will keep opening a failing pull request on every Unity Hub release.

## The change

- **`RealVersion`**: set to `<version>.65535` so the manifest carries the four-part encoding, while `Version` stays the three-part product version used for change detection and messages. Guarded on a well-formed three-part version at or above 3.21.0, so a release predating the encoding cannot pick up a wrong suffix.
- **`AppsAndFeaturesEntries`** on the two `nullsoft` installers: the NSIS installers write the three-part version into Add and Remove Programs, which no longer equals `PackageVersion`, so `DisplayVersion` is needed for upgrade correlation. `DisplayName` and `ProductCode` match the manifests published for 3.20.1 and earlier. The MSIX installers need nothing extra; they correlate by `PackageFamilyName` and identity version, which now agree with `PackageVersion` exactly.

The `msix` entries and the rest of the script are untouched.

## Notes

Four-part `PackageVersion` values are established practice for packages whose MSIX identity carries a fourth field, including `Unity.CLI` (Unity's other winget package, same encoding) and `Microsoft.PowerShell`. `Python.Python.3.x` is a live example of the `AppsAndFeaturesEntries.DisplayVersion` mapping used here.

Verified against the current feed: `latest.yml` reports `3.21.0`, which the guard maps to `3.21.0.65535`, matching the shipped MSIX identity.
